### PR TITLE
Node.js API が動作するコンテナを追加した

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     container_name: mynode
     image: node:8.11.1-alpine
     ports:
-      - 8081:8000
+      - 8000:8000
     working_dir: /home/node/app
     volumes:
       - ./keigiban-api:/home/node/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,15 @@ services:
       - 8080:80
     volumes:
       - ./webdir:/usr/local/apache2/htdocs/
+
+  node:
+    container_name: mynode
+    image: node:8.11.1-alpine
+    ports:
+      - 8081:8000
+    working_dir: /home/node/app
+    volumes:
+      - ./keigiban-api:/home/node/app
+    environment:
+      - NODE_ENV=production
+    command: node index.js

--- a/keigiban-api/index.js
+++ b/keigiban-api/index.js
@@ -7,6 +7,11 @@ console.log('Server Start');
 
 //createServerの処理
 function getinfo(request,response){
+  response.setHeader('Access-Control-Allow-Origin', '*');
+  response.setHeader('Access-Control-Request-Method', '*');
+  response.setHeader('Access-Control-Allow-Methods', 'OPTIONS, GET');
+  response.setHeader('Access-Control-Allow-Headers', '*');
+
   var url_parts = url.parse(request.url,true);
   switch (url_parts.pathname){
     case '/index':

--- a/webdir/index.html
+++ b/webdir/index.html
@@ -46,7 +46,7 @@
   <script src="https://cdn.jsdelivr.net/npm/vue@2.5.16/dist/vue.js"></script>
 
   <script>
-    const promise = jQuery.getJSON('//localhost:8081/index');
+    const promise = jQuery.getJSON(`//${location.hostname}:8000/index`);
     promise.then(value => {
       console.log(value)
       var app = new Vue({

--- a/webdir/index.html
+++ b/webdir/index.html
@@ -46,7 +46,7 @@
   <script src="https://cdn.jsdelivr.net/npm/vue@2.5.16/dist/vue.js"></script>
 
   <script>
-    const promise = jQuery.getJSON('/api/stub.json');
+    const promise = jQuery.getJSON('//localhost:8081/index');
     promise.then(value => {
       console.log(value)
       var app = new Vue({


### PR DESCRIPTION
`docker-compose up` で画面も API も起動できる。

画面チームはしばらくこれらのコンテナを利用して開発を進める想定。
Node.js サーバーに CORS 設定を追加したが、問題なければ承認お願いします。

API チームがコンテナを拡張して（例えば DB のコンテナ追加など）使うかは、相談。
EC2 のインフラ環境と二重管理になってしまう可能性があるため。